### PR TITLE
Adding DTMF (with SIP Info message) sending

### DIFF
--- a/PhpSIP.class.php
+++ b/PhpSIP.class.php
@@ -65,7 +65,7 @@ class PhpSIP
    * Allowed methods array
    */
   private $allowed_methods = array(
-    "CANCEL","NOTIFY", "INVITE","BYE","REFER","OPTIONS","SUBSCRIBE","MESSAGE", "PUBLISH", "REGISTER"
+    "CANCEL","NOTIFY", "INVITE","BYE","REFER","OPTIONS","SUBSCRIBE","MESSAGE", "PUBLISH", "REGISTER", "INFO"
   );
   
   private $server_mode = false;
@@ -779,10 +779,10 @@ class PhpSIP
       $this->readMessage();
     }
     
-    if (substr($this->res_code,0,1) == '1')
+    if (substr($this->res_code,0,1) == '1' && $this->res_code != '183')
     {
       $i = 0;
-      while (substr($this->res_code,0,1) == '1' && $i < 4)
+      while (substr($this->res_code,0,1) == '1' && $this->res_code != '183' && $i < 4)
       {
         $this->readMessage();
         $i++;

--- a/examples/dtmf.php
+++ b/examples/dtmf.php
@@ -1,0 +1,45 @@
+<?php
+require_once('../PhpSIP.class.php');
+
+try
+{
+  $api = new PhpSIP();
+  $api->setDebug(true);
+  $api->setUsername('ua1');
+  $api->setPassword('xxxxxxxx');
+  $api->setProxy('192.168.1.1');
+  $api->setMethod('INVITE');
+  $api->setFrom('sip:ua1@192.168.1.1');
+  $api->setUri('sip:ua2@192.168.1.1');
+  $res = $api->send();
+  echo "response: $res\n";
+
+  usleep(100000);
+
+  $api->setMethod('INFO');
+  $api->setContentType('application/dtmf-relay');
+  $api->setBody('Signal=*'."\r\n".'Duration=160');
+  $res = $api->send();
+  echo "response: $res\n";
+
+  usleep(100000);
+
+  $api->setMethod('INFO');
+  $api->setContentType('application/dtmf-relay');
+  $api->setBody('Signal=0'."\r\n".'Duration=160');
+  $res = $api->send();
+  echo "response: $res\n";
+
+  usleep(100000);
+
+  $api->setMethod('BYE');
+  $res = $api->send();
+  echo "response: $res\n";
+
+} catch (Exception $e) {
+
+  echo $e;
+
+}
+
+?>


### PR DESCRIPTION
This pull request enables the sending of SIP Info messages and the processing of the SIP Response Code 183. This enables the sending of DTMF signals without an active RTP session. An example documents the use of the "setMethod" function to send SIP Info messages.